### PR TITLE
Update np.float to np.float64

### DIFF
--- a/src/AIMM_simulator/AIMM_simulator.py
+++ b/src/AIMM_simulator/AIMM_simulator.py
@@ -340,7 +340,7 @@ class UE:
     s.serving_cell_ids=deque([(-1,None)]*10,maxlen=10)
     s.reporting_interval=reporting_interval
     if xyz is not None:
-      s.xyz=np.array(xyz,dtype=np.float)
+      s.xyz=np.array(xyz,dtype=np.float64)
     else:
       s.xyz=250.0+500.0*s.sim.rng.random(3)
       s.xyz[2]=h_UT


### PR DESCRIPTION
np.float is deprecated. (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

I think an alternative is to use `...dtype=float)`